### PR TITLE
Added health endpoint to the service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target/
+/.idea
+/documentationservices.iml

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ To launch the test page, open your browser at the following URL
 
     http://localhost:8080/index.html  
 
+To check the health of the application, use the following command
 
-
-
+    curl -s http://localhost:9990/health |jq
 

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
               <feature-pack-location>wildfly@maven(org.jboss.universe:community-universe)#${version.wildfly}</feature-pack-location>
               <layers>
                 <layer>jaxrs</layer>
+                <layer>microprofile-platform</layer>
               </layers>
             </configuration>
           </plugin>

--- a/src/main/java/net/adoptium/documentationservices/health/MemoryHealthCheck.java
+++ b/src/main/java/net/adoptium/documentationservices/health/MemoryHealthCheck.java
@@ -1,0 +1,26 @@
+package net.adoptium.documentationservices.health;
+
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.eclipse.microprofile.health.Liveness;
+
+import javax.enterprise.context.ApplicationScoped;
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryMXBean;
+
+@Liveness
+@ApplicationScoped
+public class MemoryHealthCheck implements HealthCheck {
+
+    @Override
+    public HealthCheckResponse call() {
+        MemoryMXBean memBean = ManagementFactory.getMemoryMXBean();
+        long memUsed = memBean.getHeapMemoryUsage().getUsed();
+        long memMax = memBean.getHeapMemoryUsage().getMax();
+
+        return HealthCheckResponse.named("Memory Check")
+                .withData("Memory used", memUsed)
+                .withData("Memory max", memMax)
+                .status(memUsed < memMax * 0.9).build();
+    }
+}


### PR DESCRIPTION
This PR has been raised to add a new health endpoint as discussed in #16 

In this issue, we have added the following :

1. Default health endpoints as provided by `microprofile-health`
2. Additional health endpoint for monitoring memory liveliness.