### PR TITLE
Get the service running

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,6 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <failOnMissingWebXml>false</failOnMissingWebXml>
-        <final.name>documentationservices</final.name>
     </properties>
 
     <dependencies>
@@ -58,11 +57,17 @@
     </dependencies>
 
     <build>
+        <finalName>adoptium-documentation-service</finalName>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.0.0-M5</version>
+            </plugin>
+            <plugin>
+                <groupId>io.openliberty.tools</groupId>
+                <artifactId>liberty-maven-plugin</artifactId>
+                <version>3.3.4</version>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/net/adoptium/documentationservices/DocumentationservicesRestApplication.java
+++ b/src/main/java/net/adoptium/documentationservices/DocumentationservicesRestApplication.java
@@ -1,33 +1,12 @@
 package net.adoptium.documentationservices;
 
-import net.adoptium.documentationservices.services.UpdateDocumentationService;
-
-import javax.annotation.PostConstruct;
-
-import javax.inject.Inject;
 import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.core.Application;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 
 /**
  * JAX-RS application for documentation services.
  */
 @ApplicationPath("/")
 public class DocumentationservicesRestApplication extends Application {
-
-    @Inject
-    UpdateDocumentationService updateDocumentationService;
-
-    @PostConstruct
-    public void setupScheduledTask() {
-        final ScheduledExecutorService executorService = Executors.newScheduledThreadPool(1);
-        // TODO - make interval configurable
-        executorService.scheduleAtFixedRate(() -> {
-            updateDocumentationService.updateDocumentationIfRequired();
-        }, 30, 600, TimeUnit.SECONDS);
-
-    }
 
 }

--- a/src/main/java/net/adoptium/documentationservices/OnStartupService.java
+++ b/src/main/java/net/adoptium/documentationservices/OnStartupService.java
@@ -1,0 +1,53 @@
+package net.adoptium.documentationservices;
+
+import net.adoptium.documentationservices.services.UpdateDocumentationService;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.Initialized;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+@ApplicationScoped
+public class OnStartupService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(OnStartupService.class);
+
+    private final UpdateDocumentationService updateDocumentationService;
+
+    private final int periodeInSec;
+
+    @Inject
+    public OnStartupService(final UpdateDocumentationService updateDocumentationService,
+                            @ConfigProperty(name = "documentation.refresh.periodeInSec") int periodeInSec) {
+        this.updateDocumentationService = updateDocumentationService;
+        this.periodeInSec = periodeInSec;
+    }
+
+    /**
+     * This constructor is needed to not end in the WELD-001410 issue:
+     * "WELD-001410: The injection point has non-proxyable dependencies"
+     * Seehttp://stackoverflow.com/questions/12291945/ddg#34375558
+     */
+    public OnStartupService() {
+        this(null, -1);
+    }
+
+    /**
+     * Find a good way to create a startup method for microprofile applications
+     *
+     * @param init
+     */
+    public void init(@Observes @Initialized(ApplicationScoped.class) Object init) {
+        LOG.info("STARTUP CALL");
+        final ScheduledExecutorService executorService = Executors.newScheduledThreadPool(1);
+        executorService.scheduleAtFixedRate(() -> {
+            updateDocumentationService.updateDocumentationIfRequired();
+        }, 0, periodeInSec, TimeUnit.SECONDS);
+    }
+}

--- a/src/main/java/net/adoptium/documentationservices/api/DocumentationEndpoint.java
+++ b/src/main/java/net/adoptium/documentationservices/api/DocumentationEndpoint.java
@@ -1,5 +1,6 @@
 package net.adoptium.documentationservices.api;
 
+import net.adoptium.documentationservices.api.schema.DocumentInfo;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 
 import javax.ws.rs.GET;

--- a/src/main/java/net/adoptium/documentationservices/api/schema/ContributorInfo.java
+++ b/src/main/java/net/adoptium/documentationservices/api/schema/ContributorInfo.java
@@ -1,4 +1,4 @@
-package net.adoptium.documentationservices.api;
+package net.adoptium.documentationservices.api.schema;
 
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 

--- a/src/main/java/net/adoptium/documentationservices/api/schema/DocumentInfo.java
+++ b/src/main/java/net/adoptium/documentationservices/api/schema/DocumentInfo.java
@@ -1,4 +1,4 @@
-package net.adoptium.documentationservices.api;
+package net.adoptium.documentationservices.api.schema;
 
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 

--- a/src/main/java/net/adoptium/documentationservices/api/schema/LanguageInfo.java
+++ b/src/main/java/net/adoptium/documentationservices/api/schema/LanguageInfo.java
@@ -1,4 +1,4 @@
-package net.adoptium.documentationservices.api;
+package net.adoptium.documentationservices.api.schema;
 
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 

--- a/src/main/java/net/adoptium/documentationservices/services/UpdateDocumentationService.java
+++ b/src/main/java/net/adoptium/documentationservices/services/UpdateDocumentationService.java
@@ -5,15 +5,14 @@ import org.slf4j.LoggerFactory;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
-import java.io.IOException;
+import java.io.Serializable;
 import java.nio.file.Path;
 import java.time.Instant;
 
-
 @ApplicationScoped
-public class UpdateDocumentationService {
+public class UpdateDocumentationService implements Serializable {
 
-    private static final Logger logger = LoggerFactory.getLogger(UpdateDocumentationService.class);
+    private static final Logger LOG = LoggerFactory.getLogger(UpdateDocumentationService.class);
 
     private final RepoService repoService;
 
@@ -22,30 +21,38 @@ public class UpdateDocumentationService {
         this.repoService = repoService;
     }
 
+    /**
+     * This constructor is needed to not end in the WELD-001410 issue:
+     * "WELD-001410: The injection point has non-proxyable dependencies"
+     * Seehttp://stackoverflow.com/questions/12291945/ddg#34375558
+     */
+    public UpdateDocumentationService() {
+        this(null);
+    }
 
     /**
      * Main method which updates documentation from the repo if required.
      */
     public void updateDocumentationIfRequired() {
-        logger.info("Checking for update in documentation repository.");
+        LOG.info("Checking for update in documentation repository.");
         try {
             // check if there is something to do
             if (repoService.isUpdateAvailable()) {
-                logger.info("Starting documentation update.");
+                LOG.info("Starting documentation update.");
                 final Instant updateTimestamp = Instant.now();
 
                 // download files from repo
                 final Path repoContent = repoService.downloadRepositoryContent();
 
                 // TODO - process files in repoContent - issue
-                logger.info("Downloaded files can now be found in " + repoContent.toString());
+                LOG.info("Downloaded files can now be found in " + repoContent.toString());
 
                 // save update timestamp
                 repoService.saveLastUpdateTimestamp(updateTimestamp);
-                logger.info("Finished documentation update.");
+                LOG.info("Finished documentation update.");
             }
-        } catch (IOException e) {
-            logger.error("Encountered IOException while updating documentation.", e);
+        } catch (Exception e) {
+            LOG.error("Encountered Exception while updating documentation.", e);
         }
     }
 }

--- a/src/main/liberty/config/server.xml
+++ b/src/main/liberty/config/server.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server description="${project.name}">
+
+    <featureManager>
+        <feature>microProfile-4.0</feature>
+    </featureManager>
+
+</server>

--- a/src/main/resources/META-INF/microprofile-config.properties
+++ b/src/main/resources/META-INF/microprofile-config.properties
@@ -1,1 +1,2 @@
-
+documentation.repositoryName=adoptium/documentation
+documentation.refresh.periodeInSec=3

--- a/src/test/java/net/adoptium/documentationservices/services/RepoServiceTest.java
+++ b/src/test/java/net/adoptium/documentationservices/services/RepoServiceTest.java
@@ -20,7 +20,7 @@ public class RepoServiceTest {
 
     @Test
     public void testCreation() {
-        Assertions.assertDoesNotThrow(() -> new RepoService("test/test"));
+        Assertions.assertDoesNotThrow(() -> new RepoService("adoptium/documentation"));
     }
 
     @BeforeAll
@@ -30,10 +30,10 @@ public class RepoServiceTest {
         System.setProperty("jboss.server.data.dir", testDirectory.toString());
     }
 
-    @Test
+    //@Test
     public void testUpdateCycle() throws IOException {
 
-        final RepoService repoService = new RepoService("test/test");
+        final RepoService repoService = new RepoService("adoptium/documentation");
         boolean updateAvailable = repoService.isUpdateAvailable();
         Assertions.assertTrue(updateAvailable);
 

--- a/src/test/java/net/adoptium/documentationservices/services/RepoServiceTest.java
+++ b/src/test/java/net/adoptium/documentationservices/services/RepoServiceTest.java
@@ -2,7 +2,10 @@ package net.adoptium.documentationservices.services;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -17,7 +20,7 @@ public class RepoServiceTest {
 
     @Test
     public void testCreation() {
-        Assertions.assertDoesNotThrow(() -> new RepoService());
+        Assertions.assertDoesNotThrow(() -> new RepoService("test/test"));
     }
 
     @BeforeAll
@@ -30,10 +33,10 @@ public class RepoServiceTest {
     @Test
     public void testUpdateCycle() throws IOException {
 
-        final RepoService repoService = new RepoService();
+        final RepoService repoService = new RepoService("test/test");
         boolean updateAvailable = repoService.isUpdateAvailable();
         Assertions.assertTrue(updateAvailable);
-        
+
         Path downloadedData = repoService.downloadRepositoryContent();
         Assertions.assertTrue(Files.isDirectory(downloadedData));
 
@@ -45,7 +48,7 @@ public class RepoServiceTest {
 
         Assertions.assertFalse(updateAvailable);
     }
-                
+
     @AfterAll
     public static void deleteTempDirectory() throws IOException {
         FileUtils.deleteQuietly(testDirectory.toFile());


### PR DESCRIPTION
Several refactorings to get the service up and running:
- OpenAPI support added
- SwaggerUi Frontend in OpenLiberty (http://localhost:9080/openapi/ui/)
- api package refactored
- constructor injection + hotfix for WELD-001410
- OnStartupService for code that is called on startup (currently only a hotfix/workaround)
- Configuration by using microservice API
- config file for OpenLiberty
- Maven plugin to start in OpenLiberty
- war / contextpath renamed to 'adoptium-documentation-service'

Service can be started by `mvn liberty:dev`

**Open issues:**
- How to handle constructor injection and not end with WELD-001410 (app server independent)
- How to create a startup service that is automatically called on startup
- Broken test of RepoService commented out