### PR TITLE
RepoService refactoring

### DIFF
--- a/src/main/java/net/adoptium/documentationservices/services/RepoService.java
+++ b/src/main/java/net/adoptium/documentationservices/services/RepoService.java
@@ -116,7 +116,7 @@ public class RepoService {
         final Instant lastUpdateTimestamp = SyncUtils.executeSynchronized(dataDirLock, () -> loadDateFromFile(lastUpdateFile));
 
         //If last update is less than 1 min, we will never update
-        if (lastUpdateTimestamp.plus(Duration.ofMinutes(1)).isAfter(Instant.now())) {
+        if (lastUpdateTimestamp.plus(Duration.ofSeconds(10)).isAfter(Instant.now())) {
             return false;
         }
         final Instant repoLastUpdated = createGitHubRepository().getUpdatedAt().toInstant();

--- a/src/main/java/net/adoptium/documentationservices/services/RepoService.java
+++ b/src/main/java/net/adoptium/documentationservices/services/RepoService.java
@@ -177,6 +177,11 @@ public class RepoService {
         });
     }
 
+    /**
+     * Clears the local data dir (that holds the repo content locally)
+     *
+     * @throws IOException
+     */
     public void clear() throws IOException {
         SyncUtils.executeSynchronized(dataDirLock, () -> {
             Files.walkFileTree(dataDir, new SimpleFileVisitor<>() {
@@ -197,6 +202,13 @@ public class RepoService {
         });
     }
 
+    /**
+     * Returns all contributors that have worked on the given documentation
+     *
+     * @param documentation the documentations
+     * @return all contributors
+     * @throws IOException
+     */
     public Set<Contributor> getContributors(final Documentation documentation) throws IOException {
         final GHRepository repo = createGitHubRepository();
 
@@ -209,7 +221,7 @@ public class RepoService {
                 //Convert to Stream
                 .flatMap(spliterator -> StreamSupport.stream(spliterator, false))
                 //Get Author
-                .map(commit -> getUser(commit))
+                .map(commit -> getAuthor(commit))
                 .filter(user -> user != null)
                 //Convert to our data object
                 .map(author -> toContributor(author))
@@ -232,7 +244,13 @@ public class RepoService {
         }
     }
 
-    private GHUser getUser(final GHCommit commit) {
+    /**
+     * Extracts the GitHub author
+     *
+     * @param commit the commit
+     * @return the author
+     */
+    private GHUser getAuthor(final GHCommit commit) {
         try {
             return Objects.requireNonNull(commit, "commit must not be null").getAuthor();
         } catch (final IOException e) {
@@ -240,6 +258,12 @@ public class RepoService {
         }
     }
 
+    /**
+     * Converts GitHub usert to our data model
+     *
+     * @param user the GitHub user
+     * @return the contributor
+     */
     private Contributor toContributor(final GHUser user) {
         try {
             return new Contributor(user.getName(), user.getAvatarUrl(), GITHUB_WEB_ADDRESS + user.getLogin());

--- a/src/main/java/net/adoptium/documentationservices/services/UpdateDocumentationService.java
+++ b/src/main/java/net/adoptium/documentationservices/services/UpdateDocumentationService.java
@@ -6,8 +6,6 @@ import org.slf4j.LoggerFactory;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import java.io.Serializable;
-import java.nio.file.Path;
-import java.time.Instant;
 
 @ApplicationScoped
 public class UpdateDocumentationService implements Serializable {
@@ -39,16 +37,8 @@ public class UpdateDocumentationService implements Serializable {
             // check if there is something to do
             if (repoService.isUpdateAvailable()) {
                 LOG.info("Starting documentation update.");
-                final Instant updateTimestamp = Instant.now();
-
                 // download files from repo
-                final Path repoContent = repoService.downloadRepositoryContent();
-
-                // TODO - process files in repoContent - issue
-                LOG.info("Downloaded files can now be found in " + repoContent.toString());
-
-                // save update timestamp
-                repoService.saveLastUpdateTimestamp(updateTimestamp);
+                repoService.downloadRepositoryContent();
                 LOG.info("Finished documentation update.");
             }
         } catch (Exception e) {

--- a/src/main/java/net/adoptium/documentationservices/util/SupplierTask.java
+++ b/src/main/java/net/adoptium/documentationservices/util/SupplierTask.java
@@ -1,0 +1,5 @@
+package net.adoptium.documentationservices.util;
+
+public interface SupplierTask<T, E extends Throwable> {
+    T run() throws E;
+}

--- a/src/main/java/net/adoptium/documentationservices/util/SupplierTask.java
+++ b/src/main/java/net/adoptium/documentationservices/util/SupplierTask.java
@@ -1,5 +1,12 @@
 package net.adoptium.documentationservices.util;
 
+/**
+ * Functional interface like {@link java.util.function.Supplier} but with the support to throw an exception.
+ *
+ * @param <T> return type
+ * @param <E> exception type
+ */
+@FunctionalInterface
 public interface SupplierTask<T, E extends Throwable> {
     T run() throws E;
 }

--- a/src/main/java/net/adoptium/documentationservices/util/SyncUtils.java
+++ b/src/main/java/net/adoptium/documentationservices/util/SyncUtils.java
@@ -1,0 +1,22 @@
+package net.adoptium.documentationservices.util;
+
+import java.util.concurrent.locks.Lock;
+
+public class SyncUtils {
+
+    public static <T, E extends Throwable> T executeSynchronized(final Lock lock, final SupplierTask<T, E> task) throws E {
+        lock.lock();
+        try {
+            return task.run();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public static <E extends Throwable> void executeSynchronized(final Lock lock, final Task<E> task) throws E {
+        executeSynchronized(lock, () -> {
+            task.run();
+            return null;
+        });
+    }
+}

--- a/src/main/java/net/adoptium/documentationservices/util/SyncUtils.java
+++ b/src/main/java/net/adoptium/documentationservices/util/SyncUtils.java
@@ -2,8 +2,11 @@ package net.adoptium.documentationservices.util;
 
 import java.util.concurrent.locks.Lock;
 
+/**
+ * Provides method to sync calls based on a {@link Lock}
+ */
 public class SyncUtils {
-
+    
     public static <T, E extends Throwable> T executeSynchronized(final Lock lock, final SupplierTask<T, E> task) throws E {
         lock.lock();
         try {

--- a/src/main/java/net/adoptium/documentationservices/util/Task.java
+++ b/src/main/java/net/adoptium/documentationservices/util/Task.java
@@ -1,0 +1,5 @@
+package net.adoptium.documentationservices.util;
+
+public interface Task<E extends Throwable> {
+    void run() throws E;
+}

--- a/src/main/java/net/adoptium/documentationservices/util/Task.java
+++ b/src/main/java/net/adoptium/documentationservices/util/Task.java
@@ -1,5 +1,11 @@
 package net.adoptium.documentationservices.util;
 
+/**
+ * Functional interface like {@link Runnable} but with the support to throw an exception.
+ *
+ * @param <E> exception type
+ */
+@FunctionalInterface
 public interface Task<E extends Throwable> {
     void run() throws E;
 }

--- a/src/test/java/net/adoptium/documentationservices/services/RepoServiceTest.java
+++ b/src/test/java/net/adoptium/documentationservices/services/RepoServiceTest.java
@@ -3,74 +3,129 @@ package net.adoptium.documentationservices.services;
 import net.adoptium.documentationservices.model.Contributor;
 import net.adoptium.documentationservices.model.Document;
 import net.adoptium.documentationservices.model.Documentation;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.RandomStringUtils;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.time.Instant;
-import java.util.HashSet;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Collections;
+import java.util.Objects;
 import java.util.Set;
 
 
 public class RepoServiceTest {
 
-    private static Path testDirectory;
+    private static final Logger LOG = LoggerFactory.getLogger(RepoServiceTest.class);
 
     @Test
     public void testCreation() {
         Assertions.assertDoesNotThrow(() -> new RepoService("adoptium/documentation"));
     }
 
-    @BeforeAll
-    public static void setUpTempDirectory() {
-        testDirectory = Paths.get("/tmp/" + RandomStringUtils.randomAlphanumeric(8));
-        testDirectory.toFile().mkdirs();
-        System.setProperty("jboss.server.data.dir", testDirectory.toString());
-    }
-
-    //@Test
-    public void testUpdateCycle() throws IOException {
-
+    @Test
+    public void testUpdateIsAvaibleAfterInit() throws IOException {
+        //given
         final RepoService repoService = new RepoService("adoptium/documentation");
-        boolean updateAvailable = repoService.isUpdateAvailable();
-        Assertions.assertTrue(updateAvailable);
 
-        Path downloadedData = repoService.downloadRepositoryContent();
-        Assertions.assertTrue(Files.isDirectory(downloadedData));
-
-        Assertions.assertTrue(Files.list(downloadedData).findAny().isPresent());
-
-        repoService.saveLastUpdateTimestamp(Instant.now());
-
-        updateAvailable = repoService.isUpdateAvailable();
-
-        Assertions.assertFalse(updateAvailable);
+        //then
+        Assertions.assertTrue(repoService.isUpdateAvailable());
     }
-
 
     @Test
-    public void testGetContributors() throws IOException {
+    public void testRepositoryDownload() throws IOException {
+        //given
+        final RepoService repoService = new RepoService("adoptium/documentation");
+
+        //when
+        final Path downloadedData = repoService.downloadRepositoryContent();
+
+        //then
+        Assertions.assertNotNull(downloadedData);
+        Assertions.assertTrue(Files.isDirectory(downloadedData));
+        Assertions.assertTrue(Files.list(downloadedData).count() > 0);
+
+        //clear the temp folder
+        repoService.clear();
+    }
+
+
+    /**
+     * Note: this test can fail if changes are commited to the repo while the test is running.
+     */
+    @Test
+    public void testRepositoryUpdatesAfterDownload() throws IOException {
+        //given
+        final RepoService repoService = new RepoService("adoptium/documentation");
+
+        //when
+        repoService.downloadRepositoryContent();
+
+        //then
+        Assertions.assertFalse(repoService.isUpdateAvailable());
+
+        //clear the temp folder
+        repoService.clear();
+    }
+
+    @Test
+    public void testGetContributors1() throws IOException {
+        //given
         final RepoService repoService = new RepoService("adoptium/documentation");
         final Document dummyDocument = new Document("index.adoc", "en");
-        Set<Document> documents = new HashSet<>();
-        documents.add(dummyDocument);
-        final Documentation dummyDoc = new Documentation("installation", documents);
+        final Documentation dummyDoc = new Documentation("installation", Collections.singleton(dummyDocument));
+
+        //when
         Set<Contributor> contributors = repoService.getContributors(dummyDoc);
 
+        //then
         Assertions.assertFalse(contributors.isEmpty());
+        Assertions.assertTrue(containsUser(contributors, "MBoegers"));
     }
 
+    @Test
+    public void testGetContributors2() throws IOException {
+        //given
+        final RepoService repoService = new RepoService("adoptium/documentation");
+        final Document dummyDocument = new Document("index.adoc", "en");
+        final Documentation dummyDoc = new Documentation("test", Collections.singleton(dummyDocument));
 
-    @AfterAll
-    public static void deleteTempDirectory() throws IOException {
-        FileUtils.deleteQuietly(testDirectory.toFile());
+        //when
+        Set<Contributor> contributors = repoService.getContributors(dummyDoc);
+
+        //then
+        Assertions.assertFalse(contributors.isEmpty());
+        Assertions.assertTrue(containsUser(contributors, "MBoegers"));
+        Assertions.assertTrue(containsUser(contributors, "CKeibel"));
     }
 
+    private boolean containsUser(Set<Contributor> contributors, String userName) {
+        return contributors.stream()
+                .map(contributor -> contributor.getGithubProfileURL())
+                .filter(url -> url.startsWith("https://github.com/"))
+                .filter(url -> url.length() > 19)
+                .filter(url -> Objects.equals(userName, url.substring(19)))
+                .count() > 0;
+    }
+
+    private void delete(final Path path) throws IOException {
+        Files.walkFileTree(path, new SimpleFileVisitor<Path>() {
+
+            @Override
+            public FileVisitResult visitFile(final Path file, final BasicFileAttributes attrs) throws IOException {
+                Files.delete(file);
+                return FileVisitResult.CONTINUE;
+            }
+
+            public FileVisitResult postVisitDirectory(final Path dir, final IOException exc) throws IOException {
+                Files.delete(dir);
+                return FileVisitResult.CONTINUE;
+            }
+        });
+    }
 }

--- a/src/test/java/net/adoptium/documentationservices/services/RepoServiceTest.java
+++ b/src/test/java/net/adoptium/documentationservices/services/RepoServiceTest.java
@@ -3,17 +3,14 @@ package net.adoptium.documentationservices.services;
 import net.adoptium.documentationservices.model.Contributor;
 import net.adoptium.documentationservices.model.Document;
 import net.adoptium.documentationservices.model.Documentation;
+import net.adoptium.documentationservices.testutils.TestUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributes;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Objects;
 import java.util.Set;
@@ -21,15 +18,13 @@ import java.util.Set;
 
 public class RepoServiceTest {
 
-    private static final Logger LOG = LoggerFactory.getLogger(RepoServiceTest.class);
-
     @Test
     public void testCreation() {
         Assertions.assertDoesNotThrow(() -> new RepoService("adoptium/documentation"));
     }
 
     @Test
-    public void testUpdateIsAvaibleAfterInit() throws IOException {
+    public void testUpdateIsAvailableAfterInit() throws IOException {
         //given
         final RepoService repoService = new RepoService("adoptium/documentation");
 
@@ -54,6 +49,38 @@ public class RepoServiceTest {
         repoService.clear();
     }
 
+    @Test
+    public void testRepositoryReDownload() throws IOException {
+        //given
+        final RepoService repoService = new RepoService("adoptium/documentation");
+
+        //when
+        final Path downloadedData = repoService.downloadRepositoryContent();
+
+        //then
+        Assertions.assertNotNull(downloadedData);
+        Assertions.assertTrue(Files.isDirectory(downloadedData));
+        Assertions.assertTrue(Files.list(downloadedData).count() > 0);
+
+        //clear the temp folder
+        repoService.clear();
+    }
+
+    @Test
+    public void testDirectRepositoryUpdatesAfterDownload() throws IOException {
+        //given
+        final RepoService repoService = new RepoService("adoptium/documentation");
+
+        //when
+        repoService.downloadRepositoryContent();
+        TestUtils.sleep(Duration.ofSeconds(12));
+
+        //then
+        Assertions.assertDoesNotThrow(() -> repoService.downloadRepositoryContent());
+
+        //clear the temp folder
+        repoService.clear();
+    }
 
     /**
      * Note: this test can fail if changes are commited to the repo while the test is running.
@@ -65,12 +92,22 @@ public class RepoServiceTest {
 
         //when
         repoService.downloadRepositoryContent();
+        TestUtils.sleep(Duration.ofSeconds(12));
 
         //then
         Assertions.assertFalse(repoService.isUpdateAvailable());
 
         //clear the temp folder
         repoService.clear();
+    }
+
+    @Test
+    public void testClearWithoutDownload() {
+        //given
+        final RepoService repoService = new RepoService("adoptium/documentation");
+
+        //then
+        Assertions.assertDoesNotThrow(() -> repoService.clear());
     }
 
     @Test
@@ -111,21 +148,5 @@ public class RepoServiceTest {
                 .filter(url -> url.length() > 19)
                 .filter(url -> Objects.equals(userName, url.substring(19)))
                 .count() > 0;
-    }
-
-    private void delete(final Path path) throws IOException {
-        Files.walkFileTree(path, new SimpleFileVisitor<Path>() {
-
-            @Override
-            public FileVisitResult visitFile(final Path file, final BasicFileAttributes attrs) throws IOException {
-                Files.delete(file);
-                return FileVisitResult.CONTINUE;
-            }
-
-            public FileVisitResult postVisitDirectory(final Path dir, final IOException exc) throws IOException {
-                Files.delete(dir);
-                return FileVisitResult.CONTINUE;
-            }
-        });
     }
 }

--- a/src/test/java/net/adoptium/documentationservices/testutils/TestUtils.java
+++ b/src/test/java/net/adoptium/documentationservices/testutils/TestUtils.java
@@ -1,0 +1,57 @@
+package net.adoptium.documentationservices.testutils;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.time.Duration;
+import java.util.Objects;
+
+public class TestUtils {
+
+    /**
+     * Sleeps for the given duration
+     *
+     * @param duration the duration
+     */
+    public static void sleep(Duration duration) {
+        final long sleepInMillis = duration.toMillis();
+        try {
+            Thread.sleep(sleepInMillis);
+        } catch (InterruptedException e) {
+            throw new RuntimeException("Interrupt while sleeping", e);
+        }
+    }
+
+    /**
+     * Deletes the given file. If it is a directory the dir and its content (recursivly) will be deleted.
+     * This is only working if the file/dir is in the local tmp folder.
+     *
+     * @param path the path that should be deleted
+     * @throws IOException
+     */
+    public static void deleteTempFile(final Path path) throws IOException {
+        final String tempDir = System.getProperty("java.io.tmpdir");
+        Objects.requireNonNull(tempDir, "error in finding temp dir");
+        final Path tmpdirPath = Path.of(tempDir);
+        if (!path.startsWith(tmpdirPath)) {
+            throw new IllegalArgumentException("Path is not in temp dir: " + path);
+        }
+
+        Files.walkFileTree(path, new SimpleFileVisitor<Path>() {
+
+            @Override
+            public FileVisitResult visitFile(final Path file, final BasicFileAttributes attrs) throws IOException {
+                Files.delete(file);
+                return FileVisitResult.CONTINUE;
+            }
+
+            public FileVisitResult postVisitDirectory(final Path dir, final IOException exc) throws IOException {
+                Files.delete(dir);
+                return FileVisitResult.CONTINUE;
+            }
+        });
+    }
+}


### PR DESCRIPTION
A refactoring of the `RepoService` that targets some issues:
- Additional tests have been added
- Access to file system (`datadir`) is synchronised
- GitHub Api wrapper is created in constructor
- Update check only does http call if last download is more than 10 sec ago
- Method to clear `datadir` added

Open problems:
- since we do not use a GitHub API key the request count has a max of 60 per hour (see https://docs.github.com/en/rest/reference/rate-limit).
