### PR TITLE
🎉 Update to Java 17 🎉

### DIFF
--- a/.github/workflows/simple-build.yml
+++ b/.github/workflows/simple-build.yml
@@ -12,10 +12,10 @@ jobs:
     steps:
         - uses: actions/checkout@v2
         - run: git checkout 
-        - name: Set up JDK 11
+        - name: Set up JDK 17
           uses: actions/setup-java@v2
           with:
-            java-version: '11'
+            java-version: '17'
             distribution: 'adopt'
         - name: Build with Maven 
           run: mvn clean verify 

--- a/pom.xml
+++ b/pom.xml
@@ -9,56 +9,65 @@
     <packaging>war</packaging>
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <failOnMissingWebXml>false</failOnMissingWebXml>
+
+        <microprofile.version>4.0.1</microprofile.version>
+        <asciidoctorj.version>2.5.3</asciidoctorj.version>
+        <github-api.version>1.303</github-api.version>
+        <zip4j.version>2.9.1</zip4j.version>
+        <slf4j-api.version>1.7.36</slf4j-api.version>
+        <microshed-testing-payara-micro.version>0.9.1</microshed-testing-payara-micro.version>
+        <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
+        <liberty-maven-plugin.version>3.5.1</liberty-maven-plugin.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>4.0.1</version>
+            <version>${microprofile.version}</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.asciidoctor</groupId>
             <artifactId>asciidoctorj</artifactId>
-            <version>2.5.2</version>
+            <version>${asciidoctorj.version}</version>
         </dependency>
         <dependency>
             <groupId>org.kohsuke</groupId>
             <artifactId>github-api</artifactId>
-            <version>1.135</version>
+            <version>${github-api.version}</version>
         </dependency>
         <dependency>
             <groupId>net.lingala.zip4j</groupId>
             <artifactId>zip4j</artifactId>
-            <version>2.9.0</version>
+            <version>${zip4j.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.32</version>
+            <version>${slf4j-api.version}</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.7.0</version>
+            <version>5.8.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.microshed</groupId>
             <artifactId>microshed-testing-payara-micro</artifactId>
-            <version>0.9.1</version>
+            <version>${microshed-testing-payara-micro.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>1.7.32</version>
+            <version>${slf4j-api.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -69,12 +78,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M5</version>
+                <version>${maven-surefire-plugin.version}</version>
             </plugin>
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.3.4</version>
+                <version>${liberty-maven-plugin.version}</version>
                 <configuration>
                     <stripVersion>true</stripVersion>
                 </configuration>


### PR DESCRIPTION
We, as member of the Eclipse Temurin project, should be using most recent versions.
I've bumped the Java version to 17 because we have no Temurin 18 build, yet.

Next Step: Update the source code to Java 17 Language level 😉